### PR TITLE
feature: CI設定

### DIFF
--- a/.github/workflows/branch_restrictions.yml
+++ b/.github/workflows/branch_restrictions.yml
@@ -1,0 +1,36 @@
+name: ブランチ制限およびPR検証
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop  # develop ブランチへのPRも監視
+
+jobs:
+  check_base_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+      
+      - name: ブランチ制限チェック
+        run: |
+          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          SOURCE_BRANCH="${{ github.event.pull_request.head.ref }}"
+          
+          echo " ブランチ制限チェック実行中..."
+          echo "  - ソース: $SOURCE_BRANCH"
+          echo "  - ターゲット: $TARGET_BRANCH"
+          
+          if [[ "$TARGET_BRANCH" == "main" ]]; then
+            if [[ "$SOURCE_BRANCH" != "develop" ]]; then
+              echo "エラー：developブランチにPRを作成してください。"
+              exit 1
+            else
+              echo "正常: developブランチからのPRです。"
+            fi
+          elif [[ "$TARGET_BRANCH" == "develop" ]]; then
+            echo "正常: developブランチへのPRです。"
+          fi
+      
+     


### PR DESCRIPTION
### やったこと
- .`github/workflows`ディレクトリに`branch_restrictions.yml`を置き、ブランチ制限の設定をした。

### 目的
- 誤って`main`ブランチに直接pushしてしまい、変更履歴が汚れるのを防ぐため。